### PR TITLE
Close #2, close #3, close #6, set and show vals for translation

### DIFF
--- a/docassemble/DALVolunteerSignup/data/questions/main.yml
+++ b/docassemble/DALVolunteerSignup/data/questions/main.yml
@@ -144,16 +144,18 @@ review:
       None
       % endif
   - Edit: volunteer.languages_known
+    show if: volunteer.interested_in['translation']
     button: |
       **Languages you can translate:**
 
-      % if volunteer.languages_known.any_true():
+      % if volunteer.interested_in['translation']:
       % for lang in volunteer.languages_known.true_values():
+      % if lang == 'Other':
+      * ${ lang }: ${ volunteer.other_languages_known }
+      % else:
       * ${ lang }
-      % endfor
-      % if volunteer.other_languages_known:
-      * Other: ${ volunteer.other_languages_known }
       % endif
+      % endfor
       % else:
       None
       % endif
@@ -174,8 +176,8 @@ code: |
       volunteer.email,
       comma_list( selected_opportunities ),
       volunteer.docassemble_experience,
-      comma_list( volunteer.languages_known.true_values() ),
-      volunteer.other_languages_known
+      comma_list( volunteer.languages_known.true_values() ) if volunteer.interested_in['translation'] else '',
+      volunteer.other_languages_known if volunteer.interested_in['translation'] and volunteer.languages_known['Other'] else ''
     ]
   )
   google_sheet_updated = True
@@ -208,15 +210,16 @@ content: |
   **Experience with Docassemble:** ${ volunteer.docassemble_experience }
   % endif
 
-  % if volunteer.languages_known.any_true():
+  % if volunteer.interested_in['translation']:
   **Languages ${ volunteer.name.first } can translate:**
   
   % for lang in volunteer.languages_known.true_values():
+  % if lang == 'Other':
+  * ${ lang }: ${ volunteer.other_languages_known }
+  % else:
   * ${ lang }
-  % endfor
-  % if volunteer.other_languages_known:
-  * Other: ${ volunteer.other_languages_known }
   % endif
+  % endfor
   % endif
 ---
 event: thank_you


### PR DESCRIPTION
Purpose of these changes:

- Closes #2
- Closes #3 
- Closes #6 

Notes:

I chose to hide the language-related values instead of deleting them. I chose to attempt to create a blank cell for the google form for those cells when the user showed no interest in translation. We can change those values if we want.

Testing:

I ran the interview manually all the way to the end. The changes seemed effective and completed with no errors. I'll have to let you check the google form.